### PR TITLE
Resolves duplicate key names

### DIFF
--- a/rancher-server/ssh.tf
+++ b/rancher-server/ssh.tf
@@ -18,7 +18,6 @@ resource "local_file" "public_key" {
 }
 
 resource "aws_key_pair" "ssh" {
-  key_name   = local.name
-  public_key = tls_private_key.ssh.public_key_openssh
+  key_name_prefix = local.name
+  public_key      = tls_private_key.ssh.public_key_openssh
 }
-

--- a/user-cluster/ssh.tf
+++ b/user-cluster/ssh.tf
@@ -18,7 +18,6 @@ resource "local_file" "public_key" {
 }
 
 resource "aws_key_pair" "ssh" {
-  key_name   = local.name
-  public_key = tls_private_key.ssh.public_key_openssh
+  key_name_prefix = local.name
+  public_key      = tls_private_key.ssh.public_key_openssh
 }
-


### PR DESCRIPTION
This PR uses `key_name_prefix` to remove the possibility of having duplicate key names in AWS between the `rancher-server` module and the `user-cluster` module.
Resolves #1 