### PR TITLE
Use asgs for masters workers

### DIFF
--- a/rancher-server/README.md
+++ b/rancher-server/README.md
@@ -58,7 +58,7 @@ module "rancher_server" {
 | rancher2\_worker\_subnet\_ids | List of subnet ids for Rancher worker nodes | list | `[]` | no |
 | rancher\_chart | Helm chart to use for Rancher install | string | `"rancher-stable/rancher"` | no |
 | rancher\_password |  | string | n/a | yes |
-| rancher\_version | Version of Rancher to install | string | `"2.2.8"` | no |
+| rancher\_version | Version of Rancher to install | string | `"2.2.9"` | no |
 | rke\_backups\_region | Region to perform backups to S3 in. Defaults to aws_region | string | `""` | no |
 | rke\_backups\_s3\_endpoint | Override for S3 endpoint to use for backups | string | `""` | no |
 | use\_default\_vpc | Should the default VPC for the region selected be used for Rancher | bool | `"true"` | no |

--- a/rancher-server/README.md
+++ b/rancher-server/README.md
@@ -57,6 +57,7 @@ module "rancher_server" {
 | rancher2\_master\_subnet\_ids | List of subnet ids for Rancher master nodes | list | `[]` | no |
 | rancher2\_worker\_subnet\_ids | List of subnet ids for Rancher worker nodes | list | `[]` | no |
 | rancher\_chart | Helm chart to use for Rancher install | string | `"rancher-stable/rancher"` | no |
+| rancher\_nodes\_in\_asgs | Control whether to put Rancher nodes in ASGs | bool | `"true"` | no |
 | rancher\_password |  | string | n/a | yes |
 | rancher\_version | Version of Rancher to install | string | `"2.2.9"` | no |
 | rke\_backups\_region | Region to perform backups to S3 in. Defaults to aws_region | string | `""` | no |

--- a/rancher-server/README.md
+++ b/rancher-server/README.md
@@ -46,7 +46,7 @@ module "rancher_server" {
 | instance\_ssh\_user | Username for sshing into instances | string | `"ubuntu"` | no |
 | instance\_type |  | string | `"t3.large"` | no |
 | le\_email | LetsEncrypt email address to use | string | `"none@none.com"` | no |
-| master\_node\_count |  | number | `"3"` | no |
+| master\_node\_count | Number of master nodes to launch | number | `"3"` | no |
 | name | Name for deployment | string | `"rancher-demo"` | no |
 | r53\_domain | DNS domain for Route53 zone (defaults to domain if unset) | string | `""` | no |
 | rancher2\_extra\_allowed\_gh\_principals | List of principals in form github_user://IDNUM to be given Rancher access | list | `[]` | no |
@@ -63,7 +63,7 @@ module "rancher_server" {
 | rke\_backups\_s3\_endpoint | Override for S3 endpoint to use for backups | string | `""` | no |
 | use\_default\_vpc | Should the default VPC for the region selected be used for Rancher | bool | `"true"` | no |
 | vpc\_id | If use_default_vpc is false, the vpc id that Rancher should use | string | `"null"` | no |
-| worker\_node\_count |  | number | `"3"` | no |
+| worker\_node\_count | Number of worker nodes to launch | number | `"3"` | no |
 
 ## Outputs
 

--- a/rancher-server/README.md
+++ b/rancher-server/README.md
@@ -40,6 +40,7 @@ module "rancher_server" {
 | certmanager\_version | Version of cert-manager to install | string | `"0.10.0"` | no |
 | creds\_output\_path | Where to save the id_rsa config file. Should end in a forward slash `/` . | string | `"./"` | no |
 | domain |  | string | `"eng.rancher.space"` | no |
+| extra\_ssh\_keys | Extra ssh keys to inject into Rancher instances | list | `[ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC06Qvs+Y9JiyOTeYNGAN/Ukq7SmeCTr7EreD1K8Lwu5VuOmo+SBZh685tNTEGV044HgFvGEOBVreDlO2ArYuwHjUBGnpQGV8/abjoeLrmZBdREAUzBQ1h2GFE/WssKUfum81cnigRK1J3tWP7emq/Y2h/Zw5F09yiCIlXMBX2auKWUCXqwG3xKTi1NVSF9N6BGyFolrAR0LZJ6k7UBXPRc/QDTclI427gSJNbnmn8LVym6YxacV/V9Y7s23iR5zYbhLPe9VJWYNk1brVvfUVb3mILVVYz76KGEq8SHdWlPQPCOp+fSJ+PezDRklnex/MmvhNrBOmMSNcpj7wSLA3hD wmaxwell@wmaxwell-laptop", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5O7k6gRYCU7YPkCH6dyXVW10izMAkDAQtQxNxdRE22 drpebcak" ]` | no |
 | github\_client\_id | GitHub client ID for Rancher to use, if using GH auth | string | `""` | no |
 | github\_client\_secret | GitHub client secret for Rancher to use, if using GH auth | string | `""` | no |
 | instance\_ssh\_user | Username for sshing into instances | string | `"ubuntu"` | no |

--- a/rancher-server/README.md
+++ b/rancher-server/README.md
@@ -40,7 +40,7 @@ module "rancher_server" {
 | certmanager\_version | Version of cert-manager to install | string | `"0.10.0"` | no |
 | creds\_output\_path | Where to save the id_rsa config file. Should end in a forward slash `/` . | string | `"./"` | no |
 | domain |  | string | `"eng.rancher.space"` | no |
-| extra\_ssh\_keys | Extra ssh keys to inject into Rancher instances | list | `[ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC06Qvs+Y9JiyOTeYNGAN/Ukq7SmeCTr7EreD1K8Lwu5VuOmo+SBZh685tNTEGV044HgFvGEOBVreDlO2ArYuwHjUBGnpQGV8/abjoeLrmZBdREAUzBQ1h2GFE/WssKUfum81cnigRK1J3tWP7emq/Y2h/Zw5F09yiCIlXMBX2auKWUCXqwG3xKTi1NVSF9N6BGyFolrAR0LZJ6k7UBXPRc/QDTclI427gSJNbnmn8LVym6YxacV/V9Y7s23iR5zYbhLPe9VJWYNk1brVvfUVb3mILVVYz76KGEq8SHdWlPQPCOp+fSJ+PezDRklnex/MmvhNrBOmMSNcpj7wSLA3hD wmaxwell@wmaxwell-laptop", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5O7k6gRYCU7YPkCH6dyXVW10izMAkDAQtQxNxdRE22 drpebcak" ]` | no |
+| extra\_ssh\_keys | Extra ssh keys to inject into Rancher instances | list | `[]` | no |
 | github\_client\_id | GitHub client ID for Rancher to use, if using GH auth | string | `""` | no |
 | github\_client\_secret | GitHub client secret for Rancher to use, if using GH auth | string | `""` | no |
 | instance\_ssh\_user | Username for sshing into instances | string | `"ubuntu"` | no |

--- a/rancher-server/data.tf
+++ b/rancher-server/data.tf
@@ -51,3 +51,11 @@ data "rancher2_user" "admin" {
   username   = "admin"
   depends_on = [rancher2_bootstrap.admin]
 }
+
+data "aws_instances" "rancher_master" {
+  filter {
+    name   = "tag:aws:autoscaling:groupName"
+    values = [aws_autoscaling_group.rancher_master.0.name]
+  }
+}
+

--- a/rancher-server/data.tf
+++ b/rancher-server/data.tf
@@ -47,10 +47,6 @@ data "helm_repository" "jetstack" {
   url  = "https://charts.jetstack.io"
 }
 
-data "template_file" "cloud_config" {
-  template = file("${path.module}/files/cloud-config.yaml")
-}
-
 data "rancher2_user" "admin" {
   username   = "admin"
   depends_on = [rancher2_bootstrap.admin]

--- a/rancher-server/data.tf
+++ b/rancher-server/data.tf
@@ -59,3 +59,9 @@ data "aws_instances" "rancher_master" {
   }
 }
 
+data "aws_instances" "rancher_worker" {
+  filter {
+    name   = "tag:aws:autoscaling:groupName"
+    values = [aws_autoscaling_group.rancher_worker.0.name]
+  }
+}

--- a/rancher-server/files/cloud-config.yaml
+++ b/rancher-server/files/cloud-config.yaml
@@ -1,7 +1,7 @@
 #cloud-config
-%{ if length(var.extra_ssh_keys) > 0 }
+%{ if length(extra_ssh_keys) > 0 }
 ssh_authorized_keys:
-%{ for ssh_key in var.extra_ssh_keys }
+%{ for ssh_key in extra_ssh_keys }
 - ${ssh_key}
 %{ endfor }
 %{ endif }

--- a/rancher-server/files/cloud-config.yaml
+++ b/rancher-server/files/cloud-config.yaml
@@ -1,7 +1,10 @@
 #cloud-config
+%{ if length(var.extra_ssh_keys) > 0 }
 ssh_authorized_keys:
-- ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC06Qvs+Y9JiyOTeYNGAN/Ukq7SmeCTr7EreD1K8Lwu5VuOmo+SBZh685tNTEGV044HgFvGEOBVreDlO2ArYuwHjUBGnpQGV8/abjoeLrmZBdREAUzBQ1h2GFE/WssKUfum81cnigRK1J3tWP7emq/Y2h/Zw5F09yiCIlXMBX2auKWUCXqwG3xKTi1NVSF9N6BGyFolrAR0LZJ6k7UBXPRc/QDTclI427gSJNbnmn8LVym6YxacV/V9Y7s23iR5zYbhLPe9VJWYNk1brVvfUVb3mILVVYz76KGEq8SHdWlPQPCOp+fSJ+PezDRklnex/MmvhNrBOmMSNcpj7wSLA3hD wmaxwell@wmaxwell-laptop
-- ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5O7k6gRYCU7YPkCH6dyXVW10izMAkDAQtQxNxdRE22 drpebcak
+%{ for ssh_key in var.extra_ssh_keys }
+- ${ssh_key}
+%{ endfor }
+%{ endif }
 runcmd:
 - apt-get update
 - apt-get install -y apt-transport-https jq software-properties-common

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -76,7 +76,7 @@ resource "aws_security_group" "rancher" {
 #############################
 resource "aws_launch_template" "rancher_master" {
   count         = local.use_asgs_for_rancher_infra ? 1 : 0
-  name_prefix   = local.name
+  name_prefix   = "${local.name}-master"
   image_id      = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
@@ -100,7 +100,39 @@ resource "aws_launch_template" "rancher_master" {
   }
 
   tags = {
-    Name        = "${local.name}-master-${count.index}"
+    Name        = "${local.name}-master"
+    DoNotDelete = "true"
+    Owner       = "EIO_Demo"
+  }
+}
+
+resource "aws_launch_template" "rancher_worker" {
+  count         = local.use_asgs_for_rancher_infra ? 1 : 0
+  name_prefix   = "${local.name}-worker"
+  image_id      = data.aws_ami.ubuntu.id
+  instance_type = local.instance_type
+  key_name      = aws_key_pair.ssh.id
+
+  user_data = base64encode(templatefile("${path.module}/files/cloud-config.yaml", { extra_ssh_keys = var.extra_ssh_keys }))
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      encrypted   = true
+      volume_type = "gp2"
+      volume_size = "50"
+    }
+  }
+
+  network_interfaces {
+    associate_public_ip_address = true
+    delete_on_termination       = true
+    security_groups             = [aws_security_group.rancher.id]
+  }
+
+  tags = {
+    Name        = "${local.name}-master"
     DoNotDelete = "true"
     Owner       = "EIO_Demo"
   }
@@ -108,7 +140,7 @@ resource "aws_launch_template" "rancher_master" {
 
 resource "aws_autoscaling_group" "rancher_master" {
   count               = local.use_asgs_for_rancher_infra ? 1 : 0
-  name_prefix         = local.name
+  name_prefix         = "${local.name}-master"
   desired_capacity    = local.master_node_count
   max_size            = local.master_node_count
   min_size            = local.master_node_count
@@ -121,11 +153,21 @@ resource "aws_autoscaling_group" "rancher_master" {
 }
 
 resource "aws_autoscaling_group" "rancher_worker" {
+  count               = local.use_asgs_for_rancher_infra ? 1 : 0
+  name_prefix         = "${local.name}-worker"
+  desired_capacity    = local.worker_node_count
+  max_size            = local.worker_node_count
+  min_size            = local.worker_node_count
+  vpc_zone_identifier = local.rancher2_worker_subnet_ids
+
+  launch_template {
+    id      = aws_launch_template.rancher_worker.0.id
+    version = "$Latest"
   }
 }
 
 resource "aws_instance" "rancher_master" {
-  count         = local.use_asgs_for_rancher_infra ? 0 : local.master_node_count
+  count         = local.master_node_count
   ami           = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
@@ -227,7 +269,7 @@ resource "null_resource" "wait_for_docker" {
   count = local.master_node_count + local.worker_node_count
 
   triggers = {
-    instance_ids = local.use_asgs_for_rancher_infra ? join(",", concat(data.aws_instances.rancher_master.ids, aws_instance.rancher_worker.*.id)) : join(",", concat(aws_instance.rancher_master.*.id, aws_instance.rancher_worker.*.id))
+    instance_ids = local.use_asgs_for_rancher_infra ? join(",", concat(data.aws_instances.rancher_worker.ids, data.aws_instances.rancher_master.ids)) : join(",", concat(aws_instance.rancher_master.*.id, aws_instance.rancher_worker.*.id))
   }
 
   provisioner "local-exec" {

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -81,7 +81,7 @@ resource "aws_launch_template" "rancher_master" {
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
 
-  user_data = data.template_file.cloud_config.rendered
+  user_data = base64encode(data.template_file.cloud_config.rendered)
 
   vpc_security_group_ids = [aws_security_group.rancher.id]
 

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -120,8 +120,9 @@ resource "aws_autoscaling_group" "rancher_master" {
 }
 
 data "aws_instances" "rancher_master" {
-  instance_tags = {
-    "aws:autoscaling:groupName" = aws_autoscaling_group.rancher_master.0.name
+  filter {
+    name   = "tag:aws:autoscaling:groupName"
+    values = [aws_autoscaling_group.rancher_master.0.name]
   }
 }
 

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -115,14 +115,14 @@ resource "aws_autoscaling_group" "rancher_master" {
   vpc_zone_identifier = local.rancher2_master_subnet_ids
 
   launch_template {
-    id      = aws_launch_template.rancher_master.id
+    id      = aws_launch_template.rancher_master.0.id
     version = "$Latest"
   }
 }
 
 data "aws_instances" "rancher_master" {
   instance_tags = {
-    "aws:autoscaling:groupName" = aws_autoscaling_group.rancher_master.name
+    "aws:autoscaling:groupName" = aws_autoscaling_group.rancher_master.0.name
   }
 }
 

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -229,7 +229,7 @@ resource "null_resource" "wait_for_docker" {
   count = local.master_node_count + local.worker_node_count
 
   triggers = {
-    instance_ids = join(",", concat(aws_instance.rancher_master.*.id, aws_instance.rancher_worker.*.id))
+    instance_ids = local.use_asgs_for_rancher_infra ? join(",", concat(data.aws_instances.rancher_master.ids, aws_instance.rancher_worker.*.id)) : join(",", concat(aws_instance.rancher_master.*.id, aws_instance.rancher_worker.*.id))
   }
 
   provisioner "local-exec" {
@@ -247,7 +247,7 @@ EOF
     environment = {
       RET  = "1"
       USER = var.instance_ssh_user
-      IP   = element(concat(aws_instance.rancher_master.*.public_ip, aws_instance.rancher_worker.*.public_ip), count.index)
+      IP   = local.use_asgs_for_rancher_infra ? element(concat(data.aws_instances.rancher_master.public_ips, aws_instance.rancher_worker.*.public_ip), count.index) : element(concat(aws_instance.rancher_master.*.public_ip, aws_instance.rancher_worker.*.public_ip), count.index)
       KEY  = "${var.creds_output_path}/id_rsa"
     }
   }

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -120,6 +120,12 @@ resource "aws_autoscaling_group" "rancher_master" {
   }
 }
 
+data "aws_instances" "rancher_master" {
+  instance_tags = {
+    "aws:autoscaling:groupName" = aws_autoscaling_group.rancher_master.name
+  }
+}
+
 resource "aws_instance" "rancher_master" {
   count         = local.use_asgs_for_rancher_infra ? 0 : local.master_node_count
   ami           = data.aws_ami.ubuntu.id

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -83,8 +83,6 @@ resource "aws_launch_template" "rancher_master" {
 
   user_data = base64encode(data.template_file.cloud_config.rendered)
 
-  vpc_security_group_ids = [aws_security_group.rancher.id]
-
   block_device_mappings {
     device_name = "/dev/sda1"
 
@@ -97,6 +95,7 @@ resource "aws_launch_template" "rancher_master" {
 
   network_interfaces {
     associate_public_ip_address = true
+    security_groups             = [aws_security_group.rancher.id]
   }
 
   tags = {

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -81,7 +81,7 @@ resource "aws_launch_template" "rancher_master" {
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
 
-  user_data = base64encode(data.template_file.cloud_config.rendered)
+  user_data = base64encode(templatefile("${path.module}/files/cloud-config.yaml"))
 
   block_device_mappings {
     device_name = "/dev/sda1"
@@ -131,7 +131,7 @@ resource "aws_instance" "rancher_master" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
-  user_data     = data.template_file.cloud_config.rendered
+  user_data     = templatefile("${path.module}/files/cloud-config.yaml")
 
   vpc_security_group_ids      = [aws_security_group.rancher.id]
   subnet_id                   = element(tolist(local.rancher2_master_subnet_ids), 0)
@@ -154,7 +154,7 @@ resource "aws_instance" "rancher_worker" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
-  user_data     = data.template_file.cloud_config.rendered
+  user_data     = templatefile("${path.module}/files/cloud-config.yaml")
 
   vpc_security_group_ids      = [aws_security_group.rancher.id]
   subnet_id                   = element(tolist(local.rancher2_worker_subnet_ids), 0)

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -167,7 +167,7 @@ resource "aws_autoscaling_group" "rancher_worker" {
 }
 
 resource "aws_instance" "rancher_master" {
-  count         = local.master_node_count
+  count         = local.use_asgs_for_rancher_infra ? 0 : local.master_node_count
   ami           = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
@@ -190,7 +190,7 @@ resource "aws_instance" "rancher_master" {
 }
 
 resource "aws_instance" "rancher_worker" {
-  count         = local.worker_node_count
+  count         = local.use_asgs_for_rancher_infra ? 0 : local.worker_node_count
   ami           = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -95,6 +95,7 @@ resource "aws_launch_template" "rancher_master" {
 
   network_interfaces {
     associate_public_ip_address = true
+    delete_on_termination       = true
     security_groups             = [aws_security_group.rancher.id]
   }
 

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -81,7 +81,7 @@ resource "aws_launch_template" "rancher_master" {
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
 
-  user_data = base64encode(templatefile("${path.module}/files/cloud-config.yaml"))
+  user_data = base64encode(templatefile("${path.module}/files/cloud-config.yaml", { extra_ssh_keys = var.extra_ssh_keys }))
 
   block_device_mappings {
     device_name = "/dev/sda1"
@@ -131,7 +131,7 @@ resource "aws_instance" "rancher_master" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
-  user_data     = templatefile("${path.module}/files/cloud-config.yaml")
+  user_data     = templatefile("${path.module}/files/cloud-config.yaml", { extra_ssh_keys = var.extra_ssh_keys })
 
   vpc_security_group_ids      = [aws_security_group.rancher.id]
   subnet_id                   = element(tolist(local.rancher2_master_subnet_ids), 0)
@@ -154,7 +154,7 @@ resource "aws_instance" "rancher_worker" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = local.instance_type
   key_name      = aws_key_pair.ssh.id
-  user_data     = templatefile("${path.module}/files/cloud-config.yaml")
+  user_data     = templatefile("${path.module}/files/cloud-config.yaml", { extra_ssh_keys = var.extra_ssh_keys })
 
   vpc_security_group_ids      = [aws_security_group.rancher.id]
   subnet_id                   = element(tolist(local.rancher2_worker_subnet_ids), 0)

--- a/rancher-server/infra.tf
+++ b/rancher-server/infra.tf
@@ -120,10 +120,7 @@ resource "aws_autoscaling_group" "rancher_master" {
   }
 }
 
-data "aws_instances" "rancher_master" {
-  filter {
-    name   = "tag:aws:autoscaling:groupName"
-    values = [aws_autoscaling_group.rancher_master.0.name]
+resource "aws_autoscaling_group" "rancher_worker" {
   }
 }
 

--- a/rancher-server/locals.tf
+++ b/rancher-server/locals.tf
@@ -34,5 +34,5 @@ locals {
     public_ip = data.aws_instances.rancher_worker.public_ips[c]
   private_ip = data.aws_instances.rancher_worker.private_ips[c] }] : aws_instance.rancher_worker[*]
 
-  use_asgs_for_rancher_infra = true
+  use_asgs_for_rancher_infra = var.rancher_nodes_in_asgs
 }

--- a/rancher-server/locals.tf
+++ b/rancher-server/locals.tf
@@ -5,8 +5,8 @@ locals {
   domain            = var.domain
   r53_domain        = length(var.r53_domain) > 0 ? var.r53_domain : local.domain
   instance_type     = var.instance_type
-  master_node_count = local.use_asgs_for_rancher_infra ? 0 : var.master_node_count
-  worker_node_count = local.use_asgs_for_rancher_infra ? 0 : var.worker_node_count
+  master_node_count = var.master_node_count
+  worker_node_count = var.worker_node_count
 
   rancher2_auth_config_github_count   = var.rancher2_github_auth_enabled ? 1 : 0
   rancher2_auth_github_user           = length(var.rancher2_github_auth_user) > 0 ? [var.rancher2_github_auth_user] : []

--- a/rancher-server/locals.tf
+++ b/rancher-server/locals.tf
@@ -25,4 +25,6 @@ locals {
 
   rancher2_master_subnet_ids = length(var.rancher2_master_subnet_ids) > 0 ? var.rancher2_master_subnet_ids : data.aws_subnet_ids.available.ids
   rancher2_worker_subnet_ids = length(var.rancher2_worker_subnet_ids) > 0 ? var.rancher2_worker_subnet_ids : data.aws_subnet_ids.available.ids
+
+  use_asgs_for_rancher_infra = true
 }

--- a/rancher-server/locals.tf
+++ b/rancher-server/locals.tf
@@ -5,8 +5,8 @@ locals {
   domain            = var.domain
   r53_domain        = length(var.r53_domain) > 0 ? var.r53_domain : local.domain
   instance_type     = var.instance_type
-  master_node_count = var.master_node_count
-  worker_node_count = var.worker_node_count
+  master_node_count = local.use_asgs_for_rancher_infra ? 0 : var.master_node_count
+  worker_node_count = local.use_asgs_for_rancher_infra ? 0 : var.worker_node_count
 
   rancher2_auth_config_github_count   = var.rancher2_github_auth_enabled ? 1 : 0
   rancher2_auth_github_user           = length(var.rancher2_github_auth_user) > 0 ? [var.rancher2_github_auth_user] : []
@@ -28,6 +28,11 @@ locals {
 
   master_instances_ips = local.use_asgs_for_rancher_infra ? [for c in range(length(data.aws_instances.rancher_master.public_ips)) : {
     public_ip = data.aws_instances.rancher_master.public_ips[c]
-  private_ip = data.aws_instances.rancher_master.private_ips[c] }] : [for c in range(length(aws_instance.rancher_master)) : aws_instance.rancher_master[c]]
+  private_ip = data.aws_instances.rancher_master.private_ips[c] }] : aws_instance.rancher_master[*]
+
+  worker_instances_ips = local.use_asgs_for_rancher_infra ? [for c in range(length(data.aws_instances.rancher_worker.public_ips)) : {
+    public_ip = data.aws_instances.rancher_worker.public_ips[c]
+  private_ip = data.aws_instances.rancher_worker.private_ips[c] }] : aws_instance.rancher_worker[*]
+
   use_asgs_for_rancher_infra = true
 }

--- a/rancher-server/locals.tf
+++ b/rancher-server/locals.tf
@@ -26,5 +26,8 @@ locals {
   rancher2_master_subnet_ids = length(var.rancher2_master_subnet_ids) > 0 ? var.rancher2_master_subnet_ids : data.aws_subnet_ids.available.ids
   rancher2_worker_subnet_ids = length(var.rancher2_worker_subnet_ids) > 0 ? var.rancher2_worker_subnet_ids : data.aws_subnet_ids.available.ids
 
+  master_instances_ips = local.use_asgs_for_rancher_infra ? [for c in range(length(data.aws_instances.rancher_master.public_ips)) : {
+    public_ip = data.aws_instances.rancher_master.public_ips[c]
+  private_ip = data.aws_instances.rancher_master.private_ips[c] }] : [for c in range(length(aws_instance.rancher_master)) : aws_instance.rancher_master[c]]
   use_asgs_for_rancher_infra = true
 }

--- a/rancher-server/rancher-ha.tf
+++ b/rancher-server/rancher-ha.tf
@@ -31,8 +31,8 @@ resource "helm_release" "cert_manager" {
 # install rancher
 resource "helm_release" "rancher" {
   name      = "rancher"
-  chart     = "v${var.rancher_chart}"
-  version   = local.rancher_version
+  chart     = var.rancher_chart
+  version   = "v${local.rancher_version}"
   namespace = "cattle-system"
 
   set {

--- a/rancher-server/rke.tf
+++ b/rancher-server/rke.tf
@@ -5,7 +5,7 @@ resource "rke_cluster" "rancher_server" {
   depends_on = [null_resource.wait_for_docker]
 
   dynamic nodes {
-    for_each = local.use_asgs_for_rancher_infra ? data.aws_instances.rancher_master.* : concat([], aws_instance.rancher_master)
+    for_each = local.master_instances_ips
     content {
       address          = nodes.value.public_ip
       internal_address = nodes.value.private_ip

--- a/rancher-server/rke.tf
+++ b/rancher-server/rke.tf
@@ -16,7 +16,7 @@ resource "rke_cluster" "rancher_server" {
   }
 
   dynamic nodes {
-    for_each = aws_instance.rancher_worker
+    for_each = local.worker_instances_ips
     content {
       address          = nodes.value.public_ip
       internal_address = nodes.value.private_ip

--- a/rancher-server/rke.tf
+++ b/rancher-server/rke.tf
@@ -5,7 +5,7 @@ resource "rke_cluster" "rancher_server" {
   depends_on = [null_resource.wait_for_docker]
 
   dynamic nodes {
-    for_each = local.use_asgs_for_rancher_infra ? data.aws_instances.rancher_master : aws_instance.rancher_master
+    for_each = local.use_asgs_for_rancher_infra ? data.aws_instances.rancher_master : concat([], aws_instance.rancher_master)
     content {
       address          = nodes.value.public_ip
       internal_address = nodes.value.private_ip

--- a/rancher-server/rke.tf
+++ b/rancher-server/rke.tf
@@ -5,7 +5,7 @@ resource "rke_cluster" "rancher_server" {
   depends_on = [null_resource.wait_for_docker]
 
   dynamic nodes {
-    for_each = local.use_asgs_for_rancher_infra ? data.aws_instances.rancher_master : concat([], aws_instance.rancher_master)
+    for_each = local.use_asgs_for_rancher_infra ? data.aws_instances.rancher_master.* : concat([], aws_instance.rancher_master)
     content {
       address          = nodes.value.public_ip
       internal_address = nodes.value.private_ip

--- a/rancher-server/rke.tf
+++ b/rancher-server/rke.tf
@@ -5,7 +5,7 @@ resource "rke_cluster" "rancher_server" {
   depends_on = [null_resource.wait_for_docker]
 
   dynamic nodes {
-    for_each = aws_instance.rancher_master
+    for_each = local.use_asgs_for_rancher_infra ? data.aws_instances.rancher_master : aws_instance.rancher_master
     content {
       address          = nodes.value.public_ip
       internal_address = nodes.value.private_ip

--- a/rancher-server/variables.tf
+++ b/rancher-server/variables.tf
@@ -8,6 +8,12 @@ variable "rancher_version" {
   description = "Version of Rancher to install"
 }
 
+variable "extra_ssh_keys" {
+  type        = list
+  default     = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC06Qvs+Y9JiyOTeYNGAN/Ukq7SmeCTr7EreD1K8Lwu5VuOmo+SBZh685tNTEGV044HgFvGEOBVreDlO2ArYuwHjUBGnpQGV8/abjoeLrmZBdREAUzBQ1h2GFE/WssKUfum81cnigRK1J3tWP7emq/Y2h/Zw5F09yiCIlXMBX2auKWUCXqwG3xKTi1NVSF9N6BGyFolrAR0LZJ6k7UBXPRc/QDTclI427gSJNbnmn8LVym6YxacV/V9Y7s23iR5zYbhLPe9VJWYNk1brVvfUVb3mILVVYz76KGEq8SHdWlPQPCOp+fSJ+PezDRklnex/MmvhNrBOmMSNcpj7wSLA3hD wmaxwell@wmaxwell-laptop", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5O7k6gRYCU7YPkCH6dyXVW10izMAkDAQtQxNxdRE22 drpebcak"]
+  description = "Extra ssh keys to inject into Rancher instances"
+}
+
 variable "rancher_chart" {
   type        = string
   default     = "rancher-stable/rancher"

--- a/rancher-server/variables.tf
+++ b/rancher-server/variables.tf
@@ -67,13 +67,15 @@ variable "instance_type" {
 }
 
 variable "master_node_count" {
-  type    = number
-  default = 3
+  type        = number
+  default     = 3
+  description = "Number of master nodes to launch"
 }
 
 variable "worker_node_count" {
-  type    = number
-  default = 3
+  type        = number
+  default     = 3
+  description = "Number of worker nodes to launch"
 }
 
 variable "instance_ssh_user" {

--- a/rancher-server/variables.tf
+++ b/rancher-server/variables.tf
@@ -10,7 +10,7 @@ variable "rancher_version" {
 
 variable "extra_ssh_keys" {
   type        = list
-  default     = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC06Qvs+Y9JiyOTeYNGAN/Ukq7SmeCTr7EreD1K8Lwu5VuOmo+SBZh685tNTEGV044HgFvGEOBVreDlO2ArYuwHjUBGnpQGV8/abjoeLrmZBdREAUzBQ1h2GFE/WssKUfum81cnigRK1J3tWP7emq/Y2h/Zw5F09yiCIlXMBX2auKWUCXqwG3xKTi1NVSF9N6BGyFolrAR0LZJ6k7UBXPRc/QDTclI427gSJNbnmn8LVym6YxacV/V9Y7s23iR5zYbhLPe9VJWYNk1brVvfUVb3mILVVYz76KGEq8SHdWlPQPCOp+fSJ+PezDRklnex/MmvhNrBOmMSNcpj7wSLA3hD wmaxwell@wmaxwell-laptop", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5O7k6gRYCU7YPkCH6dyXVW10izMAkDAQtQxNxdRE22 drpebcak"]
+  default     = []
   description = "Extra ssh keys to inject into Rancher instances"
 }
 

--- a/rancher-server/variables.tf
+++ b/rancher-server/variables.tf
@@ -78,6 +78,12 @@ variable "worker_node_count" {
   description = "Number of worker nodes to launch"
 }
 
+variable "rancher_nodes_in_asgs" {
+  type        = bool
+  default     = true
+  description = "Control whether to put Rancher nodes in ASGs"
+}
+
 variable "instance_ssh_user" {
   type        = string
   default     = "ubuntu"

--- a/rancher-server/variables.tf
+++ b/rancher-server/variables.tf
@@ -4,7 +4,7 @@ variable "rancher_password" {
 
 variable "rancher_version" {
   type        = string
-  default     = "2.2.8"
+  default     = "2.2.9"
   description = "Version of Rancher to install"
 }
 


### PR DESCRIPTION
Optionally use ASGs for master/worker nodes (defaults to ASG)

Additionally:
* fixes a bug with rancher version interpolation
* updates to latest stable rancher release for default (2.2.9)
* makes ssh key injection optional